### PR TITLE
Use pre-defined Kallisto indices

### DIFF
--- a/envs/atlas-fastq-provider.yml
+++ b/envs/atlas-fastq-provider.yml
@@ -1,4 +1,4 @@
 name: atlas-fastq-provider
 dependencies:
-  - atlas-fastq-provider=0.1.10
+  - atlas-fastq-provider=0.3.0
   - hca=6.4.0

--- a/envs/kallisto.yml
+++ b/envs/kallisto.yml
@@ -1,3 +1,3 @@
 name: kallisto
 dependencies:
-  - kallisto=0.45.0
+  - kallisto=0.46.2

--- a/main.nf
+++ b/main.nf
@@ -552,14 +552,8 @@ process synchronise_pairs {
     """          
 }
 
-// Re-use index for both single- and paired-end reads
-
-KALLISTO_INDEX.into{
-    KALLISTO_INDEX_SINGLE
-    KALLISTO_INDEX_PAIRED
-}
-
 // Run Kallisto for each single- read file
+
 process kallisto_single {
 
     conda "${baseDir}/envs/kallisto.yml"

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,7 +1,7 @@
 process {
     executor='lsf'
-    queue='$SCXA_LSF_QUEUE'
-    clusterOptions='$SCXA_LSF_OPTIONS'
+    queue="$SCXA_LSF_QUEUE"
+    clusterOptions="$SCXA_LSF_OPTIONS"
 }
 
 executor {

--- a/nextflow.config
+++ b/nextflow.config
@@ -1,6 +1,7 @@
 process {
     executor='lsf'
-    queue='production-rh74'
+    queue='$SCXA_LSF_QUEUE'
+    clusterOptions='$SCXA_LSF_OPTIONS'
 }
 
 executor {


### PR DESCRIPTION
Switch to use of predefined Kallisto indices, and update to latest software version. Indices matching this version have been placed in the Refgenie database on Codon. 