### PR TITLE
Set Nextflow to use mamba

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -18,6 +18,7 @@ executor {
 conda {
     cacheDir = "$SCXA_WORKFLOW_ROOT/envs"
     createTimeout = "30 min"
+    useMamba = true
 }
 
 params {


### PR DESCRIPTION
Set mamba as Nextflow's environment solver, as conda has recently started freezing up resulting to workflow failure.